### PR TITLE
Added lifecycle mapping for m2e support

### DIFF
--- a/twirl-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/twirl-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<lifecycleMappingMetadata>
+	<pluginExecutions>
+		<pluginExecution>
+			<pluginExecutionFilter>
+				<goals>
+					<goal>compile</goal>
+				</goals>
+			</pluginExecutionFilter>
+			<action>
+				<execute>
+					<runOnConfiguration>true</runOnConfiguration>
+					<runOnIncremental>true</runOnIncremental>
+				</execute>
+			</action>
+		</pluginExecution>
+	</pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
m2e support, so people don't have to edit individual project poms with lifecycle mappings.

Tested locally with a mvn clean install and pointing my project pom to the newly created snapshot.