### PR TITLE
added support for specifying custom twirl formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ By default the plugin looks for templates in `src/main/twirl/` and compiles to
 `target/generated-sources/twirl/`. The output folder is automatically added as a
 source root on the project.
 
+Custom template formatters can also be specified:
+
+```xml
+<plugin>
+  <groupId>com.jakewharton.twirl</groupId>
+  <artifactId>twirl-maven-plugin</artifactId>
+    ...
+  <configuration>
+    <customFormatters>custom:fully.qualified.name.CustomTwirlFormat</customFormatters>
+  </configuration>
+```
+
 The generated code is a Scala source file for each template which still need
 to be compiled using something like the [scala-maven-plugin][2].
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,10 @@
     <version>9</version>
   </parent>
 
+
   <groupId>com.jakewharton.twirl</groupId>
   <artifactId>twirl-parent</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Twirl Maven Plugin (Parent)</name>
@@ -44,9 +45,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <scala.major.version>2.12</scala.major.version>
-    <twirl.version>1.4.1</twirl.version>
+    <java.version>11</java.version>
+    <scala.major.version>2.13</scala.major.version>
+    <twirl.version>1.5.0</twirl.version>
   </properties>
 
   <dependencyManagement>
@@ -131,8 +132,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
     </plugins>
@@ -155,11 +155,11 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.0.2</version>
+          <version>4.4.0</version>
           <configuration>
             <recompileMode>incremental</recompileMode>
             <scalaCompatVersion>${scala.major.version}</scalaCompatVersion>
-            <scalaVersion>${scala.major.version}.8</scalaVersion>
+            <scalaVersion>${scala.major.version}.3</scalaVersion>
           </configuration>
         </plugin>
       </plugins>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.jakewharton.twirl</groupId>
     <artifactId>twirl-parent</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sample</artifactId>

--- a/sample/runtime/pom.xml
+++ b/sample/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.jakewharton.twirl</groupId>
     <artifactId>sample</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sample-runtime</artifactId>

--- a/sample/templates/pom.xml
+++ b/sample/templates/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.jakewharton.twirl</groupId>
     <artifactId>sample</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sample-templates</artifactId>

--- a/sample/templates/src/test/java/com/example/html/HelloTest.java
+++ b/sample/templates/src/test/java/com/example/html/HelloTest.java
@@ -7,6 +7,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HelloTest {
   @Test public void helloWorld() {
     String actual = Hello.render("world").toString();
-    assertThat(actual).isEqualTo("<h1>Hello, world!</h1>\n");
+    assertThat(actual.trim()).isEqualTo("<h1>Hello, world!</h1>");
   }
 }

--- a/sample/templates/src/test/java/com/example/html/IndexTest.java
+++ b/sample/templates/src/test/java/com/example/html/IndexTest.java
@@ -18,8 +18,7 @@ public class IndexTest {
         + "<h1>Hello, world!</h1>\n"
         + "\n"
         + "  </body>\n"
-        + "</html>\n"
-        + "\n";
-    assertThat(actual).isEqualTo(expected);
+        + "</html>";
+    assertThat(actual.replaceAll("[\r]", "").trim()).isEqualTo(expected);
   }
 }

--- a/sample/templates/src/test/java/com/example/html/NameListTest.java
+++ b/sample/templates/src/test/java/com/example/html/NameListTest.java
@@ -10,6 +10,6 @@ public class NameListTest {
   @Test public void helloWorld() {
     List<String> names = Arrays.asList("One", "Two");
     String actual = NameList.render(names).toString();
-    assertThat(actual).isEqualTo("\n<h1>Hello, One!</h1>\n\n<h1>Hello, Two!</h1>\n\n");
+    assertThat(actual.replaceAll("[\r\n]", "")).isEqualTo("<h1>Hello, One!</h1><h1>Hello, Two!</h1>");
   }
 }

--- a/twirl-maven-plugin/pom.xml
+++ b/twirl-maven-plugin/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.github.ElderResearch.twirl-maven-plugin</groupId>
   <artifactId>twirl-maven-plugin</artifactId>
-  <version>1.2.0</version>
+  <version>feature~custom_Twirl_formatter_support-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Twirl Maven Plugin</name>
   <description>Maven plugin for compiling Twirl templates.</description>

--- a/twirl-maven-plugin/pom.xml
+++ b/twirl-maven-plugin/pom.xml
@@ -8,7 +8,9 @@
     <version>1.2.1-SNAPSHOT</version>
   </parent>
 
+  <groupId>com.github.ElderResearch.twirl-maven-plugin</groupId>
   <artifactId>twirl-maven-plugin</artifactId>
+  <version>1.2.0</version>
   <packaging>maven-plugin</packaging>
   <name>Twirl Maven Plugin</name>
   <description>Maven plugin for compiling Twirl templates.</description>

--- a/twirl-maven-plugin/pom.xml
+++ b/twirl-maven-plugin/pom.xml
@@ -8,9 +8,7 @@
     <version>1.2.1-SNAPSHOT</version>
   </parent>
 
-  <groupId>com.github.ElderResearch.twirl-maven-plugin</groupId>
   <artifactId>twirl-maven-plugin</artifactId>
-  <version>feature~custom_Twirl_formatter_support-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Twirl Maven Plugin</name>
   <description>Maven plugin for compiling Twirl templates.</description>

--- a/twirl-maven-plugin/pom.xml
+++ b/twirl-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.jakewharton.twirl</groupId>
     <artifactId>twirl-parent</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>twirl-maven-plugin</artifactId>
@@ -74,13 +74,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce</id>
             <configuration>
               <rules>
-                <dependencyConvergence />
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <exclude>org.scala-lang:scala-library</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
               </rules>
             </configuration>
             <goals>

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -120,7 +119,17 @@ public final class CompileMojo extends AbstractMojo {
     	DEFAULT_FORMATTERS.forEach(formatters::put);
     	customFormatters.forEach(s -> {
     		String[] parts = s.split(":");
-    		formatters.put(parts[0], parts[1]);
+    		if (parts.length == 2) {
+    		  try {
+    		    // confirm that the specified class exists
+    		    Class.forName(parts[1]);
+    		    formatters.put(parts[0], parts[1]);
+              } catch (ClassNotFoundException e) {
+    		    log.debug("formatter class doesn't exist: " + parts[1]);
+              }
+            } else {
+    		  log.debug("skipping invalid formatter: " + s);
+            }
     	});
     }
     

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
@@ -42,8 +42,7 @@ public final class CompileMojo extends AbstractMojo {
   private static final Set<String> JAVA_IMPORTS = ImmutableSet.<String>builder()
       .add("java.lang._")
       .add("java.util._")
-      .add("scala.collection.JavaConversions._")
-      .add("scala.collection.JavaConverters._")
+      .add("scala.jdk.CollectionConverters._")
       .build();
 
   /** Directory from which to compile templates. */

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
@@ -120,13 +120,7 @@ public final class CompileMojo extends AbstractMojo {
     	customFormatters.forEach(s -> {
     		String[] parts = s.split(":");
     		if (parts.length == 2) {
-    		  try {
-    		    // confirm that the specified class exists
-    		    Class.forName(parts[1]);
-    		    formatters.put(parts[0], parts[1]);
-              } catch (ClassNotFoundException e) {
-    		    log.debug("formatter class doesn't exist: " + parts[1]);
-              }
+              formatters.put(parts[0], parts[1]);
             } else {
     		  log.debug("skipping invalid formatter: " + s);
             }

--- a/twirl-maven-plugin/src/test/java/com/jakewharton/twirl/IntegrationTest.java
+++ b/twirl-maven-plugin/src/test/java/com/jakewharton/twirl/IntegrationTest.java
@@ -36,8 +36,7 @@ public final class IntegrationTest {
     String fooBarBaz = Files.toString(fooBarBazTemplate, UTF_8);
     assertThat(fooBarBaz).contains("import java.util._")
         .contains("import java.lang._")
-        .contains("import scala.collection.JavaConversions._")
-        .contains("import scala.collection.JavaConverters._");
+        .contains("import scala.jdk.CollectionConverters._");
   }
 
   @Test public void javaImportsDisabled() throws Exception {


### PR DESCRIPTION
I added a parameter that allows users to specify custom formatters, e.g.:

`<customFormatters>fortran:com.elderresearch.fortran.FortranTwirlFormat</customFormatters>`