### PR TITLE
Feature/scala 2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <scala.major.version>2.12</scala.major.version>
-    <twirl.version>1.4.1</twirl.version>
+    <scala.major.version>2.13</scala.major.version>
+    <scala.minor.version>8</scala.minor.version>
+    <twirl.version>1.5.1</twirl.version>
   </properties>
 
   <dependencyManagement>
@@ -55,11 +56,28 @@
         <groupId>com.typesafe.play</groupId>
         <artifactId>twirl-compiler_${scala.major.version}</artifactId>
         <version>${twirl.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>${scala.major.version}.${scala.minor.version}</version>
       </dependency>
       <dependency>
         <groupId>com.typesafe.play</groupId>
         <artifactId>twirl-api_${scala.major.version}</artifactId>
         <version>${twirl.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -148,6 +166,19 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>com.jakewharton.twirl</groupId>
+          <artifactId>twirl-maven-plugin</artifactId>
+          <version>${project.version}</version>
+          <executions>
+            <execution>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
@@ -159,7 +190,7 @@
           <configuration>
             <recompileMode>incremental</recompileMode>
             <scalaCompatVersion>${scala.major.version}</scalaCompatVersion>
-            <scalaVersion>${scala.major.version}.8</scalaVersion>
+            <scalaVersion>${scala.major.version}.${scala.minor.version}</scalaVersion>
           </configuration>
         </plugin>
       </plugins>

--- a/sample/templates/pom.xml
+++ b/sample/templates/pom.xml
@@ -27,6 +27,9 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+
+<!--  make maven depend on plugin in module-->
   </dependencies>
 
   <build>
@@ -34,7 +37,9 @@
       <plugin>
         <groupId>com.jakewharton.twirl</groupId>
         <artifactId>twirl-maven-plugin</artifactId>
-        <version>${project.version}</version>
+        <configuration>
+          <useJavaHelpers>false</useJavaHelpers>
+        </configuration>
         <executions>
           <execution>
             <phase>generate-sources</phase>

--- a/twirl-maven-plugin/pom.xml
+++ b/twirl-maven-plugin/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>maven-compat</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
@@ -23,6 +23,7 @@ import play.twirl.api.JavaScriptFormat;
 import play.twirl.api.TxtFormat;
 import play.twirl.api.XmlFormat;
 import scala.io.Codec;
+import scala.tools.nsc.settings.ScalaVersion;
 
 import static com.google.common.collect.Collections2.transform;
 import static java.util.Collections.singletonList;
@@ -32,18 +33,14 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_SOURC
 @SuppressWarnings("UnusedDeclaration") // Used reflectively by Maven.
 @Mojo(name = "compile", defaultPhase = GENERATE_SOURCES, threadSafe = true)
 public final class CompileMojo extends AbstractMojo {
+
   private static final Map<String, String> FORMATTERS = ImmutableMap.<String, String>builder()
       .put("html", HtmlFormat.class.getCanonicalName())
       .put("txt", TxtFormat.class.getCanonicalName())
       .put("xml", XmlFormat.class.getCanonicalName())
       .put("js", JavaScriptFormat.class.getCanonicalName())
       .build();
-  private static final Set<String> JAVA_IMPORTS = ImmutableSet.<String>builder()
-      .add("java.lang._")
-      .add("java.util._")
-//    .add("scala.collection.JavaConversions._") removed in 2.13
-      .add("scala.collection.JavaConverters._")
-      .build();
+  private static final Set<String> JAVA_IMPORTS = ScalaVersionHelper.getJavaImport();
 
   /** Directory from which to compile templates. */
   @Parameter(defaultValue = "${project.basedir}/src/main/twirl")

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
@@ -41,7 +41,7 @@ public final class CompileMojo extends AbstractMojo {
   private static final Set<String> JAVA_IMPORTS = ImmutableSet.<String>builder()
       .add("java.lang._")
       .add("java.util._")
-//    .add("scala.collection.JavaConversions._") removed in 2.12
+//    .add("scala.collection.JavaConversions._") removed in 2.13
       .add("scala.collection.JavaConverters._")
       .build();
 

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/CompileMojo.java
@@ -41,7 +41,7 @@ public final class CompileMojo extends AbstractMojo {
   private static final Set<String> JAVA_IMPORTS = ImmutableSet.<String>builder()
       .add("java.lang._")
       .add("java.util._")
-      .add("scala.collection.JavaConversions._")
+//    .add("scala.collection.JavaConversions._") removed in 2.12
       .add("scala.collection.JavaConverters._")
       .build();
 

--- a/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/ScalaVersionHelper.java
+++ b/twirl-maven-plugin/src/main/java/com/jakewharton/twirl/ScalaVersionHelper.java
@@ -1,0 +1,50 @@
+package com.jakewharton.twirl;
+
+import com.google.common.collect.ImmutableSet;
+import scala.util.matching.Regex;
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ScalaVersionHelper {
+
+    static String getRunningScalaVersion() {
+        try {
+            //stainsby's way
+            Properties props = new java.util.Properties();
+            props.load(ScalaVersionHelper.class.getResourceAsStream("/library.properties"));
+            String line = props.getProperty("version.number");
+            Pattern version = Pattern.compile("(\\d\\.\\d+\\.\\d).*");
+            Matcher matcher = version.matcher(line);
+            if (matcher.find()) {
+                return matcher.group(1);
+            } else {
+                return "2.12";
+            }
+        } catch (Throwable e) {
+            return "2.12"; //or some other default version, or re-raise
+        }
+    }
+
+    static ImmutableSet<String> getJavaImport() {
+        if (getRunningScalaVersion().startsWith("2.13")) {
+            return JAVA_IMPORTS_2_13;
+        } else {
+            return JAVA_IMPORTS_2_12;
+        }
+    }
+
+    static
+    private final ImmutableSet<String> JAVA_IMPORTS_2_13 = ImmutableSet.<String>builder().add(
+            "java.lang._",
+            "java.util._",
+            "scala.collection.JavaConverters._"
+    ).build();
+
+    static
+    private final ImmutableSet<String> JAVA_IMPORTS_2_12 = ImmutableSet.<String>builder().add(
+            "java.lang._", "java.util._", "scala.collection.JavaConversions._", "scala.collection.JavaConverters._"
+    ).build();
+}

--- a/twirl-maven-plugin/src/test/java/com/jakewharton/twirl/IntegrationTest.java
+++ b/twirl-maven-plugin/src/test/java/com/jakewharton/twirl/IntegrationTest.java
@@ -36,7 +36,7 @@ public final class IntegrationTest {
     String fooBarBaz = Files.toString(fooBarBazTemplate, UTF_8);
     assertThat(fooBarBaz).contains("import java.util._")
         .contains("import java.lang._")
-        .contains("import scala.collection.JavaConversions._")
+//        .contains("import scala.collection.JavaConversions._")
         .contains("import scala.collection.JavaConverters._");
   }
 

--- a/twirl-maven-plugin/src/test/java/com/jakewharton/twirl/ScalaVersionHelperTest.java
+++ b/twirl-maven-plugin/src/test/java/com/jakewharton/twirl/ScalaVersionHelperTest.java
@@ -1,0 +1,16 @@
+package com.jakewharton.twirl;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class ScalaVersionHelperTest {
+
+    @Test
+    public void testVersion() throws Exception {
+        assertThat(ScalaVersionHelper.getRunningScalaVersion(), CoreMatchers.startsWith("2.13"));
+    }
+
+}


### PR DESCRIPTION
upgrade scala runtime to 2.13.8

```
Deprecated things in 2.12 that have been removed in 2.13
collection.JavaConversions. Use scala.jdk.CollectionConverters instead. Previous advice was to use collection.JavaConverters which is now deprecated ;
```

according to scala official documents,  `collection.JavaConversions`  have been removed in 2.13.
in this branch, useJavaHelpers should not add collection.JavaConversions and import anymore,  test case on it should be removed neither. 

This upgrade may break scala version compatible, adding a new configuration to switch scala-library version may help

